### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This implementation supports commands like "move forward at 0.2 m/s for 5 seconds and stop," with the `/cmd_vel` publisher named `pub_cmd_vel`.
 
+<a href="https://glama.ai/mcp/servers/@kakimochi/ros2-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kakimochi/ros2-mcp-server/badge" alt="ROS2 Server MCP server" />
+</a>
+
 ## Features
 - **MCP Integration**: Uses FastMCP to handle commands from MCP clients (e.g., Claude).
 - **ROS 2 Native**: Operates as a ROS 2 node, directly publishing to `/cmd_vel`.


### PR DESCRIPTION
This PR adds a badge for the [ROS2 MCP Server](https://glama.ai/mcp/servers/@kakimochi/ros2-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kakimochi/ros2-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kakimochi/ros2-mcp-server/badge" alt="ROS2 Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.